### PR TITLE
Added catalan translation

### DIFF
--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -1,0 +1,36 @@
+{
+  "common": {
+    "entity_missing": "Cal una entitat de tipus Meteorològic.",
+    "invalid_configuration": "La configuració no és vàlida.",
+    "invalid_forecast_days": "«Dies de previsió» ha de ser un nombre més gran que 0.",
+    "invalid_hides": "No es poden habilitar alhora les opcions «hide_today_section» i «hide_forecast_section».",
+    "invalid_time_format": "La variable time_format ha de ser «12» o «24».",
+    "version": "Versió"
+  },
+  "weather": {
+    "clear-night": "Serè",
+    "cloudy": "Ennuvolat",
+    "fog": "Boira",
+    "hail": "Calamarsa",
+    "lightning": "Tempesta elèctrica",
+    "lightning-rainy": "Tempesta",
+    "partlycloudy": "Parcialment ennuvolat",
+    "pouring": "Aiguat",
+    "rainy": "Plujós",
+    "snowy": "Neu",
+    "snowy-rainy": "Aiguaneu",
+    "sunny": "Assolellat",
+    "windy": "Ventós",
+    "windy-variant": "Vent fort",
+    "exceptional": "Excepcional"
+  },
+  "day": {
+    "0": "Dg.",
+    "1": "Dl.",
+    "2": "Dt.",
+    "3": "Dc.",
+    "4": "Dj.",
+    "5": "Dv.",
+    "6": "Ds."
+  }
+}

--- a/src/localize/localize.ts
+++ b/src/localize/localize.ts
@@ -1,5 +1,6 @@
 import * as bg from './languages/bg.json';
 import * as da from './languages/da.json';
+import * as ca from './languages/ca.json';
 import * as cz from './languages/cz.json';
 import * as de from './languages/de.json';
 import * as en from './languages/en.json';
@@ -20,6 +21,7 @@ import * as uk from './languages/uk.json';
 const languages: any = {
   bg,
   cz,
+  ca,
   da,
   de,
   en,


### PR DESCRIPTION
I noticed that this custom card didn't have the catalan language supported and I added it. Please consider to merge my contribution in your master branch.

 I've done several free software translations in the past for the KDE project and others, and I'm currently a translatio/reviewer of the catalan language pack of Moodle CMS, so I know the workflow and the quality procedures of software localization.