### PR TITLE
Feature/Remove leading 0 from 12-hour time

### DIFF
--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -372,7 +372,7 @@ export class ClockWeatherCard extends LitElement {
   }
 
   private time(): string {
-    return format(this.currentDate, this.getTimeFormat() === '24' ? 'HH:mm' : 'hh:mm aa');
+    return format(this.currentDate, this.getTimeFormat() === '24' ? 'HH:mm' : 'h:mm aa');
   }
 
   private getIconAnimationKind(): 'static' | 'animated' {


### PR DESCRIPTION
Removed the leading "0" from 12 hour time format.

Closes https://github.com/pkissling/clock-weather-card/issues/106