### PR TITLE
Add ability to be able to show more precision in main temperature displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ hide_date: false
 hourly_forecast: false
 use_browser_time: false
 time_zone: null
+show_decimal: false
 ```
 
 ### Options
@@ -142,6 +143,7 @@ time_zone: null
 | hourly_forecast       | boolean          | **Optional** | Displays an hourly forecast instead of daily                                                                                                                                                                                      | `false`   |
 | use_browser_time      | boolean          | **Optional** | Uses the time from your browser to indicate the current time. If not provided, uses the [time_zone](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/#setting-up-your-time-zone) configured in HA            | `false`   |
 | time_zone             | string           | **Optional** | Uses the given [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to indicate the current date and time. If not provided, uses the time zone configured in HA                                              | `null`    |
+| show_decimal       | boolean          | **Optional** | Displays main temperature without rounding                                                                                                                                                                                     | `false`   |
 
 ## Footnotes
 

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -209,7 +209,7 @@ export class ClockWeatherCard extends LitElement {
   private renderToday (): TemplateResult {
     const weather = this.getWeather()
     const state = weather.state
-    const temp = roundIfNotNull(this.getCurrentTemperature())
+    const temp = this.config.show_decimal ? this.getCurrentTemperature() : roundIfNotNull(this.getCurrentTemperature())
     const tempUnit = weather.attributes.temperature_unit
     const humidity = roundIfNotNull(this.getCurrentHumidity())
     const iconType = this.config.weather_icon_type
@@ -425,7 +425,8 @@ export class ClockWeatherCard extends LitElement {
       hide_date: config.hide_date ?? false,
       date_pattern: config.date_pattern ?? 'D',
       use_browser_time: config.use_browser_time ?? false,
-      time_zone: config.time_zone ?? undefined
+      time_zone: config.time_zone ?? undefined,
+      show_decimal: config.show_decimal ?? false
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface ClockWeatherCardConfig extends LovelaceCardConfig {
   hide_date?: boolean
   use_browser_time?: boolean
   time_zone?: string
+  show_decimal?: boolean
 }
 
 export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
@@ -53,6 +54,7 @@ export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
   hide_date: boolean
   use_browser_time: boolean
   time_zone?: string
+  show_decimal: boolean
 }
 
 export const enum WeatherEntityFeature {


### PR DESCRIPTION
Fixes https://github.com/pkissling/clock-weather-card/issues/111, https://github.com/pkissling/clock-weather-card/issues/355, https://github.com/pkissling/clock-weather-card/issues/316

New config added `show_decimal`.
Default is false, so that default behavior is unchanged to existing.
But now this gives the option for anyone who wants to have more precision in their temp displayed they can set `show_decimal: true`

![image](https://github.com/pkissling/clock-weather-card/assets/25592559/3c61af6d-86aa-4ae6-9b43-f43399c7f630)
