### PR TITLE
Add ability which can show the apparent temperature from a sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ hourly_forecast: false
 use_browser_time: false
 time_zone: null
 show_decimal: false
+apparent_sensor: sensor.real_feel_temperature
+show_apparent: false
 ```
 
 ### Options
@@ -144,6 +146,8 @@ show_decimal: false
 | use_browser_time      | boolean          | **Optional** | Uses the time from your browser to indicate the current time. If not provided, uses the [time_zone](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/#setting-up-your-time-zone) configured in HA            | `false`   |
 | time_zone             | string           | **Optional** | Uses the given [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to indicate the current date and time. If not provided, uses the time zone configured in HA                                              | `null`    |
 | show_decimal       | boolean          | **Optional** | Displays main temperature without rounding                                                                                                                                                                                     | `false`   |
+| apparent_sensor    | string           | **Optional** | ID of the apparent temperature sensor entity. Used to show the apparent temperature based on a sensor value                                                                                                 | `''`      |
+| show_apparent       | boolean          | **Optional** | Displays the apparent (real feel, feels like) temperature                                                                                                                                                                                     | `false`   |
 
 ## Footnotes
 

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -228,7 +228,7 @@ export class ClockWeatherCard extends LitElement {
       <clock-weather-card-today-right>
         <clock-weather-card-today-right-wrap>
           <clock-weather-card-today-right-wrap-top>
-            ${this.config.hide_clock ? weatherString : localizedTemp ? `${weatherString}, ${localizedTemp}` : weatherString }
+            ${this.config.hide_clock ? weatherString : localizedTemp ? `${weatherString}, ${localizedTemp}` : weatherString}
             ${this.config.show_humidity && localizedHumidity ? html`<br>${localizedHumidity}` : ''}
             ${this.config.show_apparent && apparentTemp ? html`<br>Feels like: ${localizedApparent}` : ''}
           </clock-weather-card-today-right-wrap-top>

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -220,7 +220,6 @@ export class ClockWeatherCard extends LitElement {
     const localizedHumidity = humidity !== null ? `${humidity}% ${this.localize('misc.humidity')}` : null
     const localizedApparent = apparentTemp !== null ? this.toConfiguredTempWithUnit(tempUnit, apparentTemp) : null
 
-
     return html`
       <clock-weather-card-today-left>
         <img class="grow-img" src=${icon} />

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -211,7 +211,7 @@ export class ClockWeatherCard extends LitElement {
     const state = weather.state
     const temp = this.config.show_decimal ? this.getCurrentTemperature() : roundIfNotNull(this.getCurrentTemperature())
     const tempUnit = weather.attributes.temperature_unit
-    const apparentTemp = this.getApparentTemperature()
+    const apparentTemp = this.config.show_decimal ? this.getApparentTemperature() : roundIfNotNull(this.getApparentTemperature())
     const humidity = roundIfNotNull(this.getCurrentHumidity())
     const iconType = this.config.weather_icon_type
     const icon = this.toIcon(state, iconType, false, this.getIconAnimationKind())

--- a/src/localize/languages/bg.json
+++ b/src/localize/languages/bg.json
@@ -26,6 +26,7 @@
     "7": "Нд"
   },
   "misc": {
-    "humidity": "влажност"
+    "humidity": "влажност",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/ca.json
+++ b/src/localize/languages/ca.json
@@ -26,6 +26,7 @@
     "7": "Dg."
   },
   "misc": {
-    "humidity": "humitat"
+    "humidity": "humitat",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -26,6 +26,7 @@
     "7": "Ne"
   },
   "misc": {
-    "humidity": "vlhkost"
+    "humidity": "vlhkost",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/da.json
+++ b/src/localize/languages/da.json
@@ -26,6 +26,7 @@
     "7": "Søn"
   },
   "misc": {
-    "humidity": "fugtighed"
+    "humidity": "fugtighed",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/de.json
+++ b/src/localize/languages/de.json
@@ -26,6 +26,7 @@
     "7": "So"
   },
   "misc": {
-    "humidity": "Luftfeuchtigkeit"
+    "humidity": "Luftfeuchtigkeit",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/el.json
+++ b/src/localize/languages/el.json
@@ -26,6 +26,7 @@
     "7": "Κυρ"
   },
   "misc": {
-    "humidity": "υγρασία"
+    "humidity": "υγρασία",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -29,5 +29,4 @@
     "humidity": "Humidity",
     "feels-like": "Feels like"
   }
-
 }

--- a/src/localize/languages/es.json
+++ b/src/localize/languages/es.json
@@ -26,6 +26,7 @@
     "7": "Dom"
   },
   "misc": {
-    "humidity": "humedad"
+    "humidity": "humedad",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/et.json
+++ b/src/localize/languages/et.json
@@ -26,6 +26,7 @@
     "7": "P"
   },
   "misc": {
-    "humidity": "niiskus"
+    "humidity": "niiskus",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/fi.json
+++ b/src/localize/languages/fi.json
@@ -26,6 +26,7 @@
     "7": "Su"
   },
   "misc": {
-    "humidity": "kosteus"
+    "humidity": "kosteus",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -26,6 +26,7 @@
     "7": "Dim"
   },
   "misc": {
-    "humidity": "humidité"
+    "humidity": "humidité",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/he.json
+++ b/src/localize/languages/he.json
@@ -26,6 +26,7 @@
     "7": "ראשון"
   },
   "misc": {
-    "humidity": "לחות"
+    "humidity": "לחות",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/hu.json
+++ b/src/localize/languages/hu.json
@@ -26,6 +26,7 @@
     "7": "V"
   },
   "misc": {
-    "humidity": "páratartalom"
+    "humidity": "páratartalom",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/is.json
+++ b/src/localize/languages/is.json
@@ -1,31 +1,32 @@
 {
-    "weather": {
-      "clear-night": "Heiðskýrt",
-      "cloudy": "Skýjað",
-      "fog": "Þoka",
-      "hail": "Hagl",
-      "lightning": "Eldingar",
-      "lightning-rainy": "Þrumur",
-      "partlycloudy": "Skýjað að hluta",
-      "pouring": "mikil rigning",
-      "rainy": "Rigning",
-      "snowy": "Snjókoma",
-      "snowy-rainy": "Él",
-      "sunny": "Sólríkt",
-      "windy": "Hvasst",
-      "windy-variant": "Stórmur",
-      "exceptional": "Óveður"
-    },
-    "day": {
-      "1": "Mán",
-      "2": "Þri",
-      "3": "Mið",
-      "4": "Fim",
-      "5": "Fös",
-      "6": "Lau",
-      "7": "Sun"
-    },
-    "misc": {
-      "humidity": "raki"
-    }
+  "weather": {
+    "clear-night": "Heiðskýrt",
+    "cloudy": "Skýjað",
+    "fog": "Þoka",
+    "hail": "Hagl",
+    "lightning": "Eldingar",
+    "lightning-rainy": "Þrumur",
+    "partlycloudy": "Skýjað að hluta",
+    "pouring": "mikil rigning",
+    "rainy": "Rigning",
+    "snowy": "Snjókoma",
+    "snowy-rainy": "Él",
+    "sunny": "Sólríkt",
+    "windy": "Hvasst",
+    "windy-variant": "Stórmur",
+    "exceptional": "Óveður"
+  },
+  "day": {
+    "1": "Mán",
+    "2": "Þri",
+    "3": "Mið",
+    "4": "Fim",
+    "5": "Fös",
+    "6": "Lau",
+    "7": "Sun"
+  },
+  "misc": {
+    "humidity": "raki",
+    "feels-like": "Feels like"
   }
+}

--- a/src/localize/languages/it.json
+++ b/src/localize/languages/it.json
@@ -26,6 +26,7 @@
     "7": "Dom"
   },
   "misc": {
-    "humidity": "umidità"
+    "humidity": "umidità",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/ko.json
+++ b/src/localize/languages/ko.json
@@ -26,6 +26,7 @@
     "7": "일"
   },
   "misc": {
-    "humidity": "습도"
+    "humidity": "습도",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/lt.json
+++ b/src/localize/languages/lt.json
@@ -26,6 +26,7 @@
     "7": "Sk"
   },
   "misc": {
-    "humidity": "drėgmė"
+    "humidity": "drėgmė",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/nb.json
+++ b/src/localize/languages/nb.json
@@ -26,6 +26,7 @@
     "7": "Søn"
   },
   "misc": {
-    "humidity": "fuktighet"
+    "humidity": "fuktighet",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -26,6 +26,7 @@
     "7": "Zo"
   },
   "misc": {
-    "humidity": "vochtigheid"
+    "humidity": "vochtigheid",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/pl.json
+++ b/src/localize/languages/pl.json
@@ -26,6 +26,7 @@
     "7": "niedz."
   },
   "misc": {
-    "humidity": "wilgotność"
+    "humidity": "wilgotność",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/pt-br.json
+++ b/src/localize/languages/pt-br.json
@@ -26,6 +26,7 @@
     "7": "Dom"
   },
   "misc": {
-    "humidity": "umidade"
+    "humidity": "umidade",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/pt.json
+++ b/src/localize/languages/pt.json
@@ -26,6 +26,7 @@
     "7": "Dom"
   },
   "misc": {
-    "humidity": "humidade"
+    "humidity": "humidade",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/ro.json
+++ b/src/localize/languages/ro.json
@@ -26,6 +26,7 @@
     "7": "Dum"
   },
   "misc": {
-    "humidity": "umiditate"
+    "humidity": "umiditate",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/ru.json
+++ b/src/localize/languages/ru.json
@@ -26,6 +26,7 @@
     "7": "Вс"
   },
   "misc": {
-    "humidity": "влажность"
+    "humidity": "влажность",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/sk.json
+++ b/src/localize/languages/sk.json
@@ -26,6 +26,7 @@
     "7": "Ned"
   },
   "misc": {
-    "humidity": "vlhkosť"
+    "humidity": "vlhkosť",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -26,6 +26,7 @@
     "7": "Ned"
   },
   "misc": {
-    "humidity": "vlažnost"
+    "humidity": "vlažnost",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/sr.json
+++ b/src/localize/languages/sr.json
@@ -1,32 +1,32 @@
 {
-    "weather": {
-      "clear-night": "Ведро",
-      "cloudy": "Облачно",
-      "fog": "Магла",
-      "hail": "Град",
-      "lightning": "Грмљавина",
-      "lightning-rainy": "Киша уз грмљавину",
-      "partlycloudy": "Делимично облачно",
-      "pouring": "Пљусак",
-      "rainy": "Киша",
-      "snowy": "Снег",
-      "snowy-rainy": "Суснежица",
-      "sunny": "Сунчано",
-      "windy": "Ветар",
-      "windy-variant": "Јак ветар",
-      "exceptional": "Изузетно"
-    },
-    "day": {
-      "1": "Пон",
-      "2": "Уто",
-      "3": "Сре",
-      "4": "Чет",
-      "5": "Пет",
-      "6": "Суб",
-      "7": "Нед"
-    },
-    "misc": {
-      "humidity": "Влажност"
-    }
+  "weather": {
+    "clear-night": "Ведро",
+    "cloudy": "Облачно",
+    "fog": "Магла",
+    "hail": "Град",
+    "lightning": "Грмљавина",
+    "lightning-rainy": "Киша уз грмљавину",
+    "partlycloudy": "Делимично облачно",
+    "pouring": "Пљусак",
+    "rainy": "Киша",
+    "snowy": "Снег",
+    "snowy-rainy": "Суснежица",
+    "sunny": "Сунчано",
+    "windy": "Ветар",
+    "windy-variant": "Јак ветар",
+    "exceptional": "Изузетно"
+  },
+  "day": {
+    "1": "Пон",
+    "2": "Уто",
+    "3": "Сре",
+    "4": "Чет",
+    "5": "Пет",
+    "6": "Суб",
+    "7": "Нед"
+  },
+  "misc": {
+    "humidity": "Влажност",
+    "feels-like": "Feels like"
   }
-  
+}

--- a/src/localize/languages/srlatn.json
+++ b/src/localize/languages/srlatn.json
@@ -26,6 +26,7 @@
     "7": "Ned"
   },
   "misc": {
-    "humidity": "Vlažnost"
+    "humidity": "Vlažnost",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/sv.json
+++ b/src/localize/languages/sv.json
@@ -26,6 +26,7 @@
     "7": "Sön"
   },
   "misc": {
-    "humidity": "fuktighet"
+    "humidity": "fuktighet",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/th.json
+++ b/src/localize/languages/th.json
@@ -26,6 +26,7 @@
     "7": "อา."
   },
   "misc": {
-    "humidity": "ความชื้น"
+    "humidity": "ความชื้น",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/tr.json
+++ b/src/localize/languages/tr.json
@@ -26,6 +26,7 @@
     "7": "Pzr"
   },
   "misc": {
-    "humidity": "nem"
+    "humidity": "nem",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/uk.json
+++ b/src/localize/languages/uk.json
@@ -26,6 +26,7 @@
     "7": "Нд"
   },
   "misc": {
-    "humidity": "вологість"
+    "humidity": "вологість",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/ur.json
+++ b/src/localize/languages/ur.json
@@ -26,6 +26,7 @@
     "7": "اتوار"
   },
   "misc": {
-    "humidity": "نمی"
+    "humidity": "نمی",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/vi.json
+++ b/src/localize/languages/vi.json
@@ -26,6 +26,7 @@
     "7": "CN"
   },
   "misc": {
-    "humidity": "độ ẩm"
+    "humidity": "độ ẩm",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/zh-cn.json
+++ b/src/localize/languages/zh-cn.json
@@ -26,6 +26,7 @@
     "7": "周日"
   },
   "misc": {
-    "humidity": "湿度"
+    "humidity": "湿度",
+    "feels-like": "Feels like"
   }
 }

--- a/src/localize/languages/zh-tw.json
+++ b/src/localize/languages/zh-tw.json
@@ -26,6 +26,7 @@
     "7": "週日"
   },
   "misc": {
-    "humidity": "濕度"
+    "humidity": "濕度",
+    "feels-like": "Feels like"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface ClockWeatherCardConfig extends LovelaceCardConfig {
   use_browser_time?: boolean
   time_zone?: string
   show_decimal?: boolean
+  apparent_sensor?: string
+  show_apparent?: boolean
 }
 
 export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
@@ -55,6 +57,8 @@ export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
   use_browser_time: boolean
   time_zone?: string
   show_decimal: boolean
+  apparent_sensor?: string
+  show_apparent: boolean
 }
 
 export const enum WeatherEntityFeature {


### PR DESCRIPTION
Fixes https://github.com/pkissling/clock-weather-card/issues/356

Allows you to specify a temperature sensor which can show the apparent temperature. This is something many weather providers provide and call it "feels like" or "real feel".

This brings it in line with the platinum-weather-card which has this feature.

![image](https://github.com/pkissling/clock-weather-card/assets/25592559/8e10854d-ec9f-4243-be89-8925d742056c)
