### PR TITLE
fix: Fix custom element define error

### DIFF
--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -154,7 +154,9 @@ class ActionHandler extends HTMLElement implements ActionHandler {
   }
 }
 
-customElements.define('action-handler-clock-weather', ActionHandler)
+if (!customElements.get('action-handler-clock-weather')) {
+  customElements.define('action-handler-clock-weather', ActionHandler)
+}
 
 const getActionHandler = (): ActionHandler => {
   const body = document.body


### PR DESCRIPTION
Fixes #409

Add a check to prevent defining the custom element 'action-handler-clock-weather' multiple times.

* Use `if (!customElements.get('action-handler-clock-weather'))` to check if the custom element is already defined before defining it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pkissling/clock-weather-card/issues/409?shareId=35ee1c1b-fd59-4315-90a5-99e41b6af9e3).