### PR TITLE
feat: Add ability to show a weather summary section (#376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ time_zone: null
 show_decimal: false
 apparent_sensor: sensor.real_feel_temperature
 aqi_sensor: sensor.air_quality_index
+summary_sensor: sensor.sydney_extended_text_0
 ```
 
 ### Options
@@ -148,6 +149,8 @@ aqi_sensor: sensor.air_quality_index
 | show_decimal          | boolean          | **Optional** | Displays main temperature without rounding                                                                                                                                                                                        | `false`   |
 | apparent_sensor       | string           | **Optional** | ID of the apparent temperature sensor entity. It is used to show the apparent temperature based on a sensor and will only show it if value is provided.                                                                           | `''`      |
 | aqi_sensor       | string           | **Optional** | ID of the Air Quality Index sensor entity. It is used to show the AQI based on a sensor and will only show it if value is provided.                                                                           | `''`      |
+| hide_summary_section  | boolean          | **Optional** | Hides the cards summary section, containing the forecasted weather text.                                                                                                                                                          | `true`    |
+| summary_sensor        | string           | **Optional** | ID of the summary text sensor entity. It is used to show the summary text for a days weather based on a sensor and will only show it if value is provided.                                                                        | `''`      |
 
 ## Footnotes
 

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -153,6 +153,7 @@ export class ClockWeatherCard extends LitElement {
 
     const showToday = !this.config.hide_today_section
     const showForecast = !this.config.hide_forecast_section
+    const showSummary = !this.config.hide_summary_section
     return html`
       <ha-card
         @action=${(e: ActionHandlerEvent) => { this.handleAction(e) }}
@@ -175,6 +176,12 @@ export class ClockWeatherCard extends LitElement {
             <clock-weather-card-today>
               ${safeRender(() => this.renderToday())}
             </clock-weather-card-today>`
+        : ''}
+          ${showSummary
+        ? html`
+            <clock-weather-card-summary>
+              ${safeRender(() => this.renderSummary())}
+            </clock-weather-card-summary>`
         : ''}
           ${showForecast
         ? html`
@@ -244,6 +251,13 @@ export class ClockWeatherCard extends LitElement {
           </clock-weather-card-today-right-wrap-bottom>
         </clock-weather-card-today-right-wrap>
       </clock-weather-card-today-right>`
+  }
+
+  private renderSummary (): TemplateResult {
+    // keep seperate in case of expanding out the summary section
+    const summaryText = this.getSummary()
+    return html`
+    ${summaryText}`
   }
 
   private renderForecast (): TemplateResult[] {
@@ -429,6 +443,7 @@ export class ClockWeatherCard extends LitElement {
       show_humidity: config.show_humidity ?? false,
       hide_forecast_section: config.hide_forecast_section ?? false,
       hide_today_section: config.hide_today_section ?? false,
+      hide_summary_section: config.hide_summary_section ?? true,
       hide_clock: config.hide_clock ?? false,
       hide_date: config.hide_date ?? false,
       date_pattern: config.date_pattern ?? 'D',
@@ -436,7 +451,8 @@ export class ClockWeatherCard extends LitElement {
       time_zone: config.time_zone ?? undefined,
       show_decimal: config.show_decimal ?? false,
       apparent_sensor: config.apparent_sensor ?? undefined,
-      aqi_sensor: config.aqi_sensor ?? undefined
+      aqi_sensor: config.aqi_sensor ?? undefined,
+      summary_sensor: config.summary_sensor ?? undefined
     }
   }
 
@@ -515,6 +531,17 @@ export class ClockWeatherCard extends LitElement {
     if (aqi <= 200) return 'red'
     if (aqi <= 300) return 'purple'
     return 'maroon'
+  }
+
+  private getSummary (): string | null {
+    if (this.config.summary_sensor) {
+      const summarySensor = this.hass.states[this.config.summary_sensor] as HassEntity | undefined
+      const summary = summarySensor?.state ? summarySensor.state : undefined
+      if (summary !== undefined && summary !== '') {
+        return summary
+      }
+    }
+    return null
   }
 
   private getSun (): HassEntityBase | undefined {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,6 +11,11 @@ export default css`
     display: flex;
   }
 
+  clock-weather-card-summary {
+    display: block;
+    padding-bottom: 5px;
+  }
+
   clock-weather-card-today-left {
     display: flex;
     width: 35%;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ClockWeatherCardConfig extends LovelaceCardConfig {
   date_pattern?: string
   hide_today_section?: boolean
   hide_forecast_section?: boolean
+  hide_summary_section?: boolean
   show_humidity?: boolean
   hourly_forecast?: boolean
   hide_clock?: boolean
@@ -33,6 +34,7 @@ export interface ClockWeatherCardConfig extends LovelaceCardConfig {
   show_decimal?: boolean
   apparent_sensor?: string
   aqi_sensor?: string
+  summary_sensor?: string
 }
 
 export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
@@ -50,6 +52,7 @@ export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
   date_pattern: string
   hide_today_section: boolean
   hide_forecast_section: boolean
+  hide_summary_section: boolean
   show_humidity: boolean
   hourly_forecast: boolean
   hide_clock: boolean
@@ -59,6 +62,7 @@ export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
   show_decimal: boolean
   apparent_sensor?: string
   aqi_sensor?: string
+  summary_sensor?: string
 }
 
 export const enum WeatherEntityFeature {


### PR DESCRIPTION
Adds a weather summary section, keeping it similar to other sections.

By default will be hidden, unless: 

```yaml
hide_summary_section: false
summary_sensor: sensor.sydney_extended_text_0
```

![image](https://github.com/user-attachments/assets/86a4af51-8fb5-48a6-b729-058581e81fd6)

