### PR TITLE
Update to Czech transtation

### DIFF
--- a/src/localize/languages/cs.json
+++ b/src/localize/languages/cs.json
@@ -14,7 +14,7 @@
     "sunny": "Slunečno",
     "windy": "Vítr",
     "windy-variant": "Prudký vítr",
-    "exceptional": "Chaos"
+    "exceptional": "Nevšední"
   },
   "day": {
     "1": "Po",


### PR DESCRIPTION
Hi,
I would like to change the translation of the status "exceptional" because "chaos" is not appropriate and it does not describe in our language possible meteorological conditions and could be misleading.