### PR TITLE
Update sl.json

### DIFF
--- a/src/localize/languages/sl.json
+++ b/src/localize/languages/sl.json
@@ -28,6 +28,6 @@
   "misc": {
     "aqi": "AQI",
     "humidity": "vlažnost",
-    "feels-like": "Feels like"
+    "feels-like": "Občutek temperature"
   }
 }


### PR DESCRIPTION
#523 provided a translation for feels-like, so adding that.

At the same time, I noticed two things that I don't know if you want to update:

1. All localizations with a western alphabet seem to use AQI and nothing else.  If you want to translate it, the same issue provided a translation
2. All localizations with a western alphabet have humidity as lower case, while all other attributes are upper case.  I left this alone