### PR TITLE
Fix: Improve AQI Text Readability on Light Backgrounds

### DIFF
--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -213,7 +213,8 @@ export class ClockWeatherCard extends LitElement {
     const tempUnit = weather.attributes.temperature_unit
     const apparentTemp = this.config.show_decimal ? this.getApparentTemperature() : roundIfNotNull(this.getApparentTemperature())
     const aqi = this.getAqi()
-    const aqiColor = this.getAqiColor(aqi)
+    const aqiBackgroundColor = this.getAqiBackgroundColor(aqi)
+    const aqiTextColor = this.getAqiTextColor(aqi)
     const humidity = roundIfNotNull(this.getCurrentHumidity())
     const iconType = this.config.weather_icon_type
     const icon = this.toIcon(state, iconType, false, this.getIconAnimationKind())
@@ -234,7 +235,7 @@ export class ClockWeatherCard extends LitElement {
             ${this.config.hide_clock ? weatherString : localizedTemp ? `${weatherString}, ${localizedTemp}` : weatherString}
             ${this.config.show_humidity && localizedHumidity ? html`<br>${localizedHumidity}` : ''}
             ${this.config.apparent_sensor && apparentTemp ? html`<br>${apparentString}: ${localizedApparent}` : ''}
-            ${this.config.aqi_sensor && aqi !== null ? html`<br><aqi style="background-color: ${aqiColor}">${aqi} ${aqiString}</aqi>` : ''}
+            ${this.config.aqi_sensor && aqi !== null ? html`<br><aqi style="background-color: ${aqiBackgroundColor}; color: ${aqiTextColor};">${aqi} ${aqiString}</aqi>` : ''}
           </clock-weather-card-today-right-wrap-top>
           <clock-weather-card-today-right-wrap-center>
             ${this.config.hide_clock ? localizedTemp ?? 'n/a' : this.time()}
@@ -505,7 +506,7 @@ export class ClockWeatherCard extends LitElement {
     return null
   }
 
-  private getAqiColor (aqi: number | null): string | null {
+  private getAqiBackgroundColor (aqi: number | null): string | null {
     if (aqi == null) {
       return null
     }
@@ -515,6 +516,15 @@ export class ClockWeatherCard extends LitElement {
     if (aqi <= 200) return '#FF0000'
     if (aqi <= 300) return '#9400D3'
     return '#8B0000'
+  }
+
+  private getAqiTextColor (aqi: number | null): string {
+    // Use black text for light backgrounds (green, yellow, orange) for better readability.
+    if (aqi !== null && aqi <= 150) {
+      return '#000000'
+    }
+    // Use white text for dark backgrounds (red, purple, maroon).
+    return '#FFFFFF'
   }
 
   private getSun (): HassEntityBase | undefined {


### PR DESCRIPTION
#### Problem

The AQI (Air Quality Index) indicator uses a background color that corresponds to the current air quality level. For "Good" or "Moderate" levels, this background is a light color like green or yellow.

On themes with white text (such as the default Home Assistant dark theme), this created a low-contrast combination of white text on a light background, making the AQI value very difficult to read. This is a significant usability and accessibility issue.

<img width="579" height="465" alt="image" src="https://github.com/user-attachments/assets/b4a5157a-9b07-42f2-b591-37a800e7dd8d" />

#### Solution

This PR introduces a dynamic text color for the AQI indicator to ensure high contrast in all scenarios.

- The `getAqiColor` method has been renamed to `getAqiBackgroundColor` for clarity.
- A new method, `getAqiTextColor`, has been added. This method returns:
    - **Black (`#000000`)** for lighter backgrounds (green, yellow, orange).
    - **White (`#FFFFFF`)** for darker backgrounds (red, purple, maroon).
- The card's render method now applies both the background and text color, guaranteeing legibility.

With this change, the AQI text is now always clear and easy to read, regardless of the air quality value or the user's theme.