### PR TITLE
Add getEntitySuggestion to offer the card in the entity picker

### DIFF
--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -46,7 +46,14 @@ console.info(
 (window as any).customCards.push({
   type: 'clock-weather-card',
   name: 'Clock Weather Card',
-  description: 'Shows the current date/time in combination with the current weather and an iOS insipired weather forecast.'
+  description: 'Shows the current date/time in combination with the current weather and an iOS insipired weather forecast.',
+  getEntitySuggestion: (_hass: HomeAssistant, entityId: string): { config: Record<string, unknown> } | null => {
+    if (entityId.split('.')[0] !== 'weather') {
+      return null
+    }
+
+    return { config: { type: 'custom:clock-weather-card', entity: entityId } }
+  }
 })
 
 const gradientMap: Map<number, Rgb> = new Map()


### PR DESCRIPTION
Home Assistant 2026.6 adds `getEntitySuggestion`, which lets a custom card offer itself in the entity card picker. This suggests the card for `weather` entities, generating `{ type: "custom:clock-weather-card", entity: entityId }`.

Docs: https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity
