### PR TITLE
feat: add horizontal forecast layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ show_humidity: false
 hide_clock: false
 hide_date: false
 hourly_forecast: false
+forecast_layout: rows
 use_browser_time: false
 time_zone: null
 show_decimal: false
@@ -143,6 +144,7 @@ aqi_sensor: sensor.air_quality_index
 | hide_clock            | boolean          | **Optional** | Hides the clock from the today section and prominently displays the current temperature instead                                                                                                                                   | `false`   |
 | hide_date             | boolean          | **Optional** | Hides the date from the today section                                                                                                                                                                                             | `false`   |
 | hourly_forecast       | boolean          | **Optional** | Displays an hourly forecast instead of daily                                                                                                                                                                                      | `false`   |
+| forecast_layout       | string           | **Optional** | Layout of the forecast section. `rows` renders one row per period; `horizontal` renders a single strip of columns (label, icon, temperature), which is much shorter vertically. Independent of `hourly_forecast`, which selects the data.                                        | `rows`    |
 | use_browser_time      | boolean          | **Optional** | Uses the time from your browser to indicate the current time. If not provided, uses the [time_zone](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/#setting-up-your-time-zone) configured in HA            | `false`   |
 | time_zone             | string           | **Optional** | Uses the given [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to indicate the current date and time. If not provided, uses the time zone configured in HA                                              | `null`    |
 | show_decimal          | boolean          | **Optional** | Displays main temperature without rounding                                                                                                                                                                                        | `false`   |

--- a/src/clock-weather-card.ts
+++ b/src/clock-weather-card.ts
@@ -270,7 +270,29 @@ export class ClockWeatherCard extends LitElement {
       .map(d => hourly ? this.time(d) : this.localize(`day.${d.weekday}`))
     const maxColOneChars = displayTexts.length ? max(displayTexts.map(t => t.length)) : 0
 
+    if (this.config.forecast_layout === 'horizontal') {
+      return [safeRender(() => this.renderForecastStrip(forecasts, temperatureUnit, displayTexts))]
+    }
+
     return forecasts.map((forecast, i) => safeRender(() => this.renderForecastItem(forecast, minTemp, maxTemp, currentTemp, temperatureUnit, hourly, displayTexts[i], maxColOneChars)))
+  }
+
+  private renderForecastStrip (forecasts: MergedWeatherForecast[], temperatureUnit: TemperatureUnit, displayTexts: string[]): TemplateResult {
+    return html`
+      <clock-weather-card-forecast-strip>
+        ${forecasts.map((forecast, i) => {
+          const weatherState = forecast.condition === 'pouring' ? 'raindrops' : forecast.condition === 'rainy' ? 'raindrop' : forecast.condition
+          const weatherIcon = this.toIcon(weatherState, 'fill', true, 'static')
+          const temp = this.toConfiguredTempWithUnit(temperatureUnit, Math.round(forecast.temperature))
+          return html`
+            <clock-weather-card-forecast-slot>
+              <forecast-slot-text>${displayTexts[i]}</forecast-slot-text>
+              <forecast-slot-icon><img class="grow-img" src=${weatherIcon} /></forecast-slot-icon>
+              <forecast-slot-text>${temp}</forecast-slot-text>
+            </clock-weather-card-forecast-slot>`
+        })}
+      </clock-weather-card-forecast-strip>
+    `
   }
 
   private renderForecastItem (forecast: MergedWeatherForecast, minTemp: number, maxTemp: number, currentTemp: number | null, temperatureUnit: TemperatureUnit, hourly: boolean, displayText: string, maxColOneChars: number): TemplateResult {
@@ -453,6 +475,7 @@ export class ClockWeatherCard extends LitElement {
       weather_icon_type: config.weather_icon_type ?? 'line',
       forecast_rows: config.forecast_rows ?? 5,
       hourly_forecast: config.hourly_forecast ?? false,
+      forecast_layout: config.forecast_layout ?? 'rows',
       animated_icon: config.animated_icon ?? true,
       time_format: config.time_format?.toString() as '12' | '24' | undefined,
       time_pattern: config.time_pattern ?? undefined,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -130,4 +130,40 @@ export default css`
     padding: 2px;
     border-radius: 5px;
   }
+
+  clock-weather-card-forecast-strip {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 0.5rem;
+    width: 100%;
+  }
+
+  clock-weather-card-forecast-slot {
+    display: flex;
+    flex: 1 1 0;
+    min-width: 0;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.15rem;
+  }
+
+  forecast-slot-text {
+    white-space: nowrap;
+    text-align: center;
+  }
+
+  forecast-slot-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+
+  forecast-slot-icon img {
+    width: 100%;
+    max-width: 2.5rem;
+    height: auto;
+  }
 `

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface ClockWeatherCardConfig extends LovelaceCardConfig {
   hide_forecast_section?: boolean
   show_humidity?: boolean
   hourly_forecast?: boolean
+  forecast_layout?: 'rows' | 'horizontal'
   hide_clock?: boolean
   hide_date?: boolean
   use_browser_time?: boolean
@@ -52,6 +53,7 @@ export interface MergedClockWeatherCardConfig extends LovelaceCardConfig {
   hide_forecast_section: boolean
   show_humidity: boolean
   hourly_forecast: boolean
+  forecast_layout: 'rows' | 'horizontal'
   hide_clock: boolean
   hide_date: boolean
   use_browser_time: boolean


### PR DESCRIPTION
Adds `forecast_layout: rows | horizontal`, defaulting to `rows` so existing behaviour is unchanged.

With `horizontal`, the forecast renders as a single strip of columns - label, icon, temperature - instead of one row per period. This is considerably shorter vertically, which makes it practical to show an hourly forecast alongside the today section on a dashboard where height is limited.

It is orthogonal to `hourly_forecast`: that still selects the data, while `forecast_layout` only changes presentation, so a compact daily strip is also possible. `forecast_rows` becomes the column count. Labels reuse the same `displayTexts` array as the row layout, so `time_format`, `locale` and `time_pattern` behave identically.

Here is an example how it looks like: 

<img width="938" height="481" alt="image" src="https://github.com/user-attachments/assets/5dbd83aa-b881-461b-988f-970d46c69ee4" />
